### PR TITLE
Refactoring calendar body and add events to calendar

### DIFF
--- a/force-app/main/default/lwc/calendarBody/calendarBody.css
+++ b/force-app/main/default/lwc/calendarBody/calendarBody.css
@@ -11,12 +11,21 @@
     text-align: center;
 }
 
+.day {
+    float: right;
+    border: 0.5px solid rgb(154, 154, 154);
+    height: 150px;
+    padding-left: 6px;
+    padding-top: 3px;
+    font-weight: 500;
+}
+
 .month-title {
     text-transform: capitalize;
     text-align: center;
     font-weight: 550;
     font-size: 20px;
-    color: #244B6D;
+    color: #244b6d;
 }
 
 .month-title-1 {
@@ -24,7 +33,7 @@
     text-align: center;
     font-weight: 550;
     font-size: 20px;
-    color: #244B6D;
+    color: #244b6d;
 }
 
 .nav-button {

--- a/force-app/main/default/lwc/calendarBody/calendarBody.html
+++ b/force-app/main/default/lwc/calendarBody/calendarBody.html
@@ -37,7 +37,12 @@
             <span> Søn </span>
         </div>
         <template for:each={monthDays} for:item="monthDay">
-            <div class="slds-col slds-size_1-of-7 day" key={monthDay.date}>{monthDay.day}</div>
+            <div class="slds-col slds-size_1-of-7 day" key={monthDay.date}>
+                {monthDay.day}
+                <template for:each={monthDay.events} for:item="event">
+                    <div key={event.StartDate}>{event.Subject}</div>
+                </template>
+            </div>
         </template>
     </div>
 </template>

--- a/force-app/main/default/lwc/calendarBody/calendarBody.html
+++ b/force-app/main/default/lwc/calendarBody/calendarBody.html
@@ -1,18 +1,43 @@
 <template>
-        <main class="slds-grid slds-grid_align-end main-container">
-            <lightning-button
-                label="<"
-                title="Non-primary action"
-                onclick={handlePrev}
-                class="slds-x-small nav-button"
-            ></lightning-button>
-            <h1 class="month-title">{currentMonth}</h1>
-            <lightning-button
-                label=">"
-                title="Non-primary action"
-                onclick={handleNext}
-                class="slds-x-small nav-button"
-            ></lightning-button>
+    <main class="slds-grid slds-grid_align-end main-container">
+        <lightning-button
+            label="<"
+            title="Non-primary action"
+            onclick={handlePrev}
+            class="slds-x-small nav-button"
+        ></lightning-button>
+        <h1 class="month-title">{currentMonth}</h1>
+        <lightning-button
+            label=">"
+            title="Non-primary action"
+            onclick={handleNext}
+            class="slds-x-small nav-button"
+        ></lightning-button>
     </main>
-    <div class="slds-grid slds-wrap calendar-container"></div>
+    <div class="slds-grid slds-wrap calendar-container">
+        <div class="slds-col slds-size_1-of-7 day-header">
+            <span> Man </span>
+        </div>
+        <div class="slds-col slds-size_1-of-7 day-header">
+            <span> Tir </span>
+        </div>
+        <div class="slds-col slds-size_1-of-7 day-header">
+            <span> Ons </span>
+        </div>
+        <div class="slds-col slds-size_1-of-7 day-header">
+            <span> Tor </span>
+        </div>
+        <div class="slds-col slds-size_1-of-7 day-header">
+            <span> Fre </span>
+        </div>
+        <div class="slds-col slds-size_1-of-7 day-header">
+            <span> Lør </span>
+        </div>
+        <div class="slds-col slds-size_1-of-7 day-header">
+            <span> Søn </span>
+        </div>
+        <template for:each={monthDays} for:item="monthDay">
+            <div class="slds-col slds-size_1-of-7 day" key={monthDay.date}>{monthDay.day}</div>
+        </template>
+    </div>
 </template>

--- a/force-app/main/default/lwc/calendarBody/calendarBody.js
+++ b/force-app/main/default/lwc/calendarBody/calendarBody.js
@@ -7,6 +7,7 @@ export default class CalendarBody extends LightningElement {
     monthNav = 0;
     currentMonth = '';
     monthDays = [];
+    eventsForMonth = [];
 
     @track workOrders;
     @wire(getAllWorkOrders)
@@ -28,12 +29,8 @@ export default class CalendarBody extends LightningElement {
 
     load() {
         const dt = new Date();
+        this.eventsForMonth = [];
         this.monthDays = [];
-        if (this.workOrders) {
-            this.workOrders.forEach((wo) => {
-                console.log('Show StartDate: ', wo.StartDate);
-            });
-        }
 
         if (this.monthNav !== 0) {
             dt.setMonth(new Date().getMonth() + this.monthNav);
@@ -81,13 +78,31 @@ export default class CalendarBody extends LightningElement {
 
         this.currentMonth = `${dt.toLocaleDateString('no', { month: 'long' })} ${year}`;
 
+        if (this.workOrders) {
+            this.workOrders.forEach((wo) => {
+                //console.log('WorkOrder: ', new Date(wo.StartDate));
+                const workOrderDate = new Date(wo.StartDate);
+                if (workOrderDate.getMonth() == month) {
+                    this.eventsForMonth.push(wo);
+                }
+            });
+        }
+
         for (let i = 1; i <= paddingDaysFirst + daysInMonth; i++) {
+            let eventsForDay = [];
             const dateOfTheDay = new Date(year, month, i - paddingDaysFirst);
             if (i > paddingDaysFirst && i <= daysInMonth + paddingDaysFirst) {
+                this.eventsForMonth.forEach((event) => {
+                    if (dateOfTheDay.getDate() == new Date(event.StartDate).getDate()) {
+                        eventsForDay.push(event);
+                    }
+                });
                 this.monthDays.push({
                     day: i - paddingDaysFirst,
-                    date: dateOfTheDay
+                    date: dateOfTheDay,
+                    events: eventsForDay
                 });
+                console.log(this.monthDays);
             } else if (i <= paddingDaysFirst) {
                 this.monthDays.push({});
             }

--- a/force-app/main/default/lwc/calendarBody/calendarBody.js
+++ b/force-app/main/default/lwc/calendarBody/calendarBody.js
@@ -4,9 +4,9 @@ import getAllWorkOrders from '@salesforce/apex/CalendarWorkOrdersController.getA
 export default class CalendarBody extends LightningElement {
     weekdays = ['mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag', 'søndag'];
     reversedWeekdays = ['mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag', 'søndag'].reverse();
-    calendarContainer = document.getElementsByClassName('calendar-container');
     monthNav = 0;
-    currentMonth = 'Test';
+    currentMonth = '';
+    monthDays = [];
 
     @track workOrders;
     @wire(getAllWorkOrders)
@@ -15,22 +15,22 @@ export default class CalendarBody extends LightningElement {
             console.log('DATA WORKS: ', result.data);
             this.workOrders = result.data;
             //console.log('Show StartDate: ', this.workOrders[0].StartDate);
-            this.load(this.template.querySelector('div'));
+            this.load();
         }
     }
 
     handlePrev() {
         this.monthNav--;
-        this.load(this.template.querySelector('div'));
+        this.load();
     }
     handleNext() {
         this.monthNav++;
-        this.load(this.template.querySelector('div'));
+        this.load();
     }
 
-    load(element) {
+    load() {
         const dt = new Date();
-
+        this.monthDays = [];
         if (this.workOrders) {
             this.workOrders.forEach((wo) => {
                 console.log('Show StartDate: ', wo.StartDate);
@@ -83,51 +83,17 @@ export default class CalendarBody extends LightningElement {
 
         this.currentMonth = `${dt.toLocaleDateString('no', { month: 'long' })} ${year}`;
 
-        element.innerHTML = `
-        <div class="slds-col slds-size_1-of-7 day-header">
-            <span> Man </span>
-        </div>
-        <div class="slds-col slds-size_1-of-7 day-header">
-            <span> Tir </span>
-        </div>
-        <div class="slds-col slds-size_1-of-7 day-header">
-            <span> Ons </span>
-        </div>
-        <div class="slds-col slds-size_1-of-7 day-header">
-            <span> Tor </span>
-        </div>
-        <div class="slds-col slds-size_1-of-7 day-header">
-            <span> Fre </span>
-        </div>
-        <div class="slds-col slds-size_1-of-7 day-header">
-            <span> Lør </span>
-        </div>
-        <div class="slds-col slds-size_1-of-7 day-header">
-            <span> Søn </span>
-        </div>`;
-
-        for (let i = 1; i <= paddingDaysFirst + daysInMonth + paddingDaysLast; i++) {
-            const daySquare = document.createElement('div');
-            daySquare.classList.add('day');
-            daySquare.classList.add('slds-col');
-            daySquare.classList.add('slds-size_1-of-7');
-            daySquare.style.float = 'right';
-            daySquare.style.border = '0.5px solid rgb(154, 154, 154)';
-            daySquare.style.height = '150px';
-            daySquare.style.paddingLeft = '6px';
-            daySquare.style.paddingTop = '3px';
-            daySquare.style.fontWeight = '500';
-
-            if (i > paddingDaysFirst && i <= daysInMonth + 1) {
-                daySquare.innerText = i - paddingDaysFirst;
+        for (let i = 1; i <= paddingDaysFirst + daysInMonth; i++) {
+            const dateOfTheDay = new Date(year, month, i - paddingDaysFirst);
+            if (i > paddingDaysFirst && i <= daysInMonth + paddingDaysFirst) {
+                this.monthDays.push({
+                    day: i - paddingDaysFirst,
+                    date: dateOfTheDay
+                });
             } else if (i <= paddingDaysFirst) {
-                daySquare.innerText = prevPaddingDays[i - 1];
-                daySquare.style.opacity = '0.5';
+                this.monthDays.push({});
             } else if (i > daysInMonth) {
-                daySquare.innerText = nextPaddingDays[i - 1];
             }
-
-            element.appendChild(daySquare);
         }
     }
 }

--- a/force-app/main/default/lwc/calendarBody/calendarBody.js
+++ b/force-app/main/default/lwc/calendarBody/calendarBody.js
@@ -12,9 +12,7 @@ export default class CalendarBody extends LightningElement {
     @wire(getAllWorkOrders)
     wiredGetAllWorkOrders(result) {
         if (result.data) {
-            console.log('DATA WORKS: ', result.data);
             this.workOrders = result.data;
-            //console.log('Show StartDate: ', this.workOrders[0].StartDate);
             this.load();
         }
     }
@@ -92,7 +90,6 @@ export default class CalendarBody extends LightningElement {
                 });
             } else if (i <= paddingDaysFirst) {
                 this.monthDays.push({});
-            } else if (i > daysInMonth) {
             }
         }
     }

--- a/force-app/main/default/lwc/calendarWorkorders/calendarWorkorders.html
+++ b/force-app/main/default/lwc/calendarWorkorders/calendarWorkorders.html
@@ -1,22 +1,4 @@
 <template>
-    <lightning-card title="WorkOrdersWohooo" icon-name="custom:custom14">
-        <ul class="slds-m-around_medium">
-            <template for:each={workOrders} for:item="workOrder">
-                <li key={workOrder.Id}>
-                    {workOrder.Subject}, {workOrder.StartDate}, {workOrder.EndDate} -- {workOrder.Id}
-                </li>
-            </template>
-        </ul>
-    </lightning-card>
-
-    <lightning-card title="Accounts" icon-name="custom:custom7">
-        <ul class="slds-m-around_medium">
-            <template for:each={allAccounts} for:item="account">
-                <li key={account.Id}>{account.Name} -- {account.Id} -- {account.relatedId}</li>
-            </template>
-        </ul>
-    </lightning-card>
-
     <lightning-card title="ServiceAppointments" icon-name="custom:custom3">
         <ul class="slds-m-around_medium">
             <template for:each={allServiceAppointments} for:item="serviceAppointment">


### PR DESCRIPTION
Endret slik at koden lager object med alle dagene og bruker dermed template for:each for å tegne kalenderen. Har også kommet på en løsning for å vise events i kalenderen på riktige dager (foreløpig med work orders). Vi har ikke merget sammen med oppdatert backend enda.